### PR TITLE
Try setting up a writable overlay for /etc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
           arch: x86_64
           image_name: ${{ env.MY_IMAGE_NAME }}
           image_repo: ${{ env.IMAGE_REGISTRY }}
-          variant: base
+          variant: Silverblue
           version: 40
           image_tag: "latest"
           iso_name: ${{ env.MY_IMAGE_NAME }}-latest.iso

--- a/Containerfile
+++ b/Containerfile
@@ -33,7 +33,7 @@ ARG SOURCE_IMAGE="bluefin"
 # - stable-zfs
 # - stable-nvidia-zfs
 # - (and the above with testing rather than stable)
-ARG SOURCE_SUFFIX="-main"
+ARG SOURCE_SUFFIX=""
 
 ## SOURCE_TAG arg must be a version built for the specific image: eg, 39, 40, gts, latest
 ARG SOURCE_TAG="latest"

--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@
 # - "base"
 #
 #  "aurora", "bazzite", "bluefin" or "ucore" may also be used but have different suffixes.
-ARG SOURCE_IMAGE="base"
+ARG SOURCE_IMAGE="bluefin"
 
 ## SOURCE_SUFFIX arg should include a hyphen and the appropriate suffix name
 # These examples all work for silverblue/kinoite/sericea/onyx/lazurite/vauxite/base

--- a/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
+++ b/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
@@ -70,7 +70,7 @@ systemctl restart --no-block sockets.target timers.target multi-user.target defa
 # /etc overlay in the presence of confexts:
 ETC_WORKDIR=/var/lib/overlays/workdirs/etc
 mkdir -p $ETC_WORKDIR
-ETC_UPPERDIR=/var/lib/overlays/overrides/etc
+ETC_UPPERDIR=/var/lib/extensions.mutable/etc
 mkdir -p $ETC_UPPERDIR
 mkdir -p $ETC_REBIND
 mount --bind /etc $ETC_REBIND

--- a/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
+++ b/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
@@ -56,16 +56,11 @@ else
   # TODO(ethanjli): mark the next staged pallet as having failed to be applied
 fi
 
-echo "Updating systemd..."
+echo "Updating systemd extensions..."
 systemd-sysext refresh
 systemd-confext refresh
-systemctl daemon-reload
-# This was shamelessly ripped from https://www.youtube.com/watch?t=1087&v=EMH8_97OAPg:
-systemctl restart --no-block sockets.target timers.target multi-user.target default.target
-# (you could probably use `systemctl isolate multi-user.target` instead if you understood the
-# consequences of doing so; but I'm personally not sure I fully understand those consequences, so
-# I'll just stick with what Flatcar Container Linux uses/used, tyvm)
 
+echo "Remounting /etc as a writeable overlay..."
 # Set up a writable /etc overlay in the meantime until systemd 256 is able to make a writable
 # /etc overlay in the presence of confexts:
 ETC_WORKDIR=/var/lib/overlays/workdirs/etc
@@ -78,6 +73,14 @@ mount -t overlay overlay -o workdir=$ETC_WORKDIR,upperdir=$ETC_UPPERDIR,lowerdir
 # (Note: this might interact extremely poorly with ostree's three-way merge for /etc - I haven't
 # tested it or thought through it very carefully. Use at your own risk, and please file bug
 # reports if you notice bad behavior!)
+
+echo "Updating systemd services..."
+systemctl daemon-reload
+# This was shamelessly ripped from https://www.youtube.com/watch?t=1087&v=EMH8_97OAPg:
+systemctl restart --no-block sockets.target timers.target multi-user.target default.target
+# (you could probably use `systemctl isolate multi-user.target` instead if you understood the
+# consequences of doing so; but I'm personally not sure I fully understand those consequences, so
+# I'll just stick with what Flatcar Container Linux uses/used, tyvm)
 
 if [ -f /var/run/docker.sock ]; then
   echo "Updating Docker Compose apps..."

--- a/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
+++ b/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
@@ -69,7 +69,7 @@ systemctl restart --no-block sockets.target timers.target multi-user.target defa
 # Set up a writable /etc overlay in the meantime until systemd 256 is able to make a writable
 # /etc overlay in the presence of confexts:
 ETC_WORKDIR=/var/lib/overlays/workdirs/etc
-mkdir -p $ETCWORKDIR
+mkdir -p $ETC_WORKDIR
 ETC_UPPERDIR=/var/lib/overlays/overrides/etc
 mkdir -p $ETC_UPPERDIR
 mkdir -p $ETC_REBIND

--- a/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
+++ b/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
@@ -26,6 +26,13 @@ fi
 if mountpoint -q "$CONFEXT_TARGET"; then
   umount -l "$CONFEXT_TARGET"
 fi
+if mountpoint -q /etc; then
+  umount -l /etc
+fi
+ETC_REBIND=/var/lib/overlays/bases/etc
+if mountpoint -q "$ETC_REBIND"; then
+  umount -l "$ETC_REBIND"
+fi
 
 if [ -d $NEXT_BUNDLE_EXTENSIONS ]; then
   # Bind mounts will fail if the targets don't already exist:
@@ -58,6 +65,19 @@ systemctl restart --no-block sockets.target timers.target multi-user.target defa
 # (you could probably use `systemctl isolate multi-user.target` instead if you understood the
 # consequences of doing so; but I'm personally not sure I fully understand those consequences, so
 # I'll just stick with what Flatcar Container Linux uses/used, tyvm)
+
+# Set up a writable /etc overlay in the meantime until systemd 256 is able to make a writable
+# /etc overlay in the presence of confexts:
+ETC_WORKDIR=/var/lib/overlays/workdirs/etc
+mkdir -p $ETCWORKDIR
+ETC_UPPERDIR=/var/lib/overlays/overrides/etc
+mkdir -p $ETC_UPPERDIR
+mkdir -p $ETC_REBIND
+mount --bind /etc $ETC_REBIND
+mount -t overlay overlay -o workdir=$ETC_WORKDIR,upperdir=$ETC_UPPERDIR,lowerdir=$ETC_REBIND /etc
+# (Note: this might interact extremely poorly with ostree's three-way merge for /etc - I haven't
+# tested it or thought through it very carefully. Use at your own risk, and please file bug
+# reports if you notice bad behavior!)
 
 if [ -f /var/run/docker.sock ]; then
   echo "Updating Docker Compose apps..."

--- a/system_files/forklift-extensions/usr/lib/systemd/system/forklift-stage-apply-systemd.service
+++ b/system_files/forklift-extensions/usr/lib/systemd/system/forklift-stage-apply-systemd.service
@@ -25,10 +25,12 @@ ExecStart=forklift-stage-apply-systemd
 # however, this is probably acceptable behavior for us at shutdown because our mounts are read-only,
 # and any orphaned file handles for the writable overlay mount for `/etc` are still valid because
 # they write into the upperdir (presumably?):
+ExecStopPost=systemd-sysext unmerge
 ExecStopPost=umount -l /var/lib/extensions
-ExecStopPost=umount -l /var/lib/confexts
-ExecStopPost=umount -l /var/lib/overlays/bases/etc
 ExecStopPost=umount -l /etc
+ExecStopPost=umount -l /var/lib/overlays/bases/etc
+ExecStopPost=systemd-confext unmerge
+ExecStopPost=umount -l /var/lib/confexts
 # (if anyone recommends a cleaner way to unmount these paths, please notify @ethanjli on Discord or
 # lietk12@gmail.com !)
 

--- a/system_files/forklift-extensions/usr/lib/systemd/system/forklift-stage-apply-systemd.service
+++ b/system_files/forklift-extensions/usr/lib/systemd/system/forklift-stage-apply-systemd.service
@@ -22,9 +22,13 @@ RemainAfterExit=true
 ExecStart=forklift-stage-apply-systemd
 # Note: `umount -l` is not recommended in general (see https://unix.stackexchange.com/a/390057)
 # because it just removes the mounts from the namespace while writes to open files can continue;
-# however, this is probably acceptable behavior for us at shutdown because our mounts are read-only:
+# however, this is probably acceptable behavior for us at shutdown because our mounts are read-only,
+# and any orphaned file handles for the writable overlay mount for `/etc` are still valid because
+# they write into the upperdir (presumably?):
 ExecStopPost=umount -l /var/lib/extensions
 ExecStopPost=umount -l /var/lib/confexts
+ExecStopPost=umount -l /var/lib/overlays/bases/etc
+ExecStopPost=umount -l /etc
 # (if anyone recommends a cleaner way to unmount these paths, please notify @ethanjli on Discord or
 # lietk12@gmail.com !)
 


### PR DESCRIPTION
This PR attempts to modify `forklift-stage-apply-systemd` to remount `/etc` as a writable overlay after systemd-confext performs its own FS overlay magic on `/etc`. I don't know how such functionality might interact with ostree's 3-way merge of `/etc` - presumably any files the user causes to exist in the upperdir of the writable `/etc` overlaly will override whatever ostree's 3-way merge does to the respective files in the base `/etc`.