### PR TITLE
Try switching from base to bluefin with immutable `/usr`/`/etc`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
           arch: x86_64
           image_name: ${{ env.MY_IMAGE_NAME }}
           image_repo: ${{ env.IMAGE_REGISTRY }}
-          variant: base
+          variant: silverblue
           version: 40
           image_tag: "latest"
           iso_name: ${{ env.MY_IMAGE_NAME }}-latest.iso

--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@
 # - "base"
 #
 #  "aurora", "bazzite", "bluefin" or "ucore" may also be used but have different suffixes.
-ARG SOURCE_IMAGE="base"
+ARG SOURCE_IMAGE="bluefin"
 
 ## SOURCE_SUFFIX arg should include a hyphen and the appropriate suffix name
 # These examples all work for silverblue/kinoite/sericea/onyx/lazurite/vauxite/base
@@ -33,7 +33,7 @@ ARG SOURCE_IMAGE="base"
 # - stable-zfs
 # - stable-nvidia-zfs
 # - (and the above with testing rather than stable)
-ARG SOURCE_SUFFIX="-main"
+ARG SOURCE_SUFFIX=""
 
 ## SOURCE_TAG arg must be a version built for the specific image: eg, 39, 40, gts, latest
 ARG SOURCE_TAG="latest"


### PR DESCRIPTION
This PR is meant as an experimental control for #1 (which switches from base to bluefin with a mutable overlay for `/etc` - but no mutable overlay for `/etc`) to check whether there are any problems with switching from base to bluefin without setting up any mutable overlays for either `/etc` or `/usr`. Previously, there were some [reports](https://discord.com/channels/1072614816579063828/1207724265516957706/1235023907615150181) that a mutable overlay for `/usr` was needed to make GUI logins work; #1 doesn't set up a mutable overlay for `/usr` but it does set up a mutable overlay for `/etc`, so this new PR is meant to check whether the mutable overlay for `/etc` is actually necessary to make GUI logins work, or whether something else (e.g. setting SELinux to permissive mode) is sufficient to make GUI logins work.