### PR TITLE
Downgrade from Fedora 40 to Fedora 39

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
           image_name: ${{ env.MY_IMAGE_NAME }}
           image_repo: ${{ env.IMAGE_REGISTRY }}
           variant: Silverblue
-          version: 40
+          version: 39
           image_tag: "latest"
           iso_name: ${{ env.MY_IMAGE_NAME }}-latest.iso
           enable_cache_dnf: "false"

--- a/Containerfile
+++ b/Containerfile
@@ -36,7 +36,7 @@ ARG SOURCE_IMAGE="bluefin"
 ARG SOURCE_SUFFIX=""
 
 ## SOURCE_TAG arg must be a version built for the specific image: eg, 39, 40, gts, latest
-ARG SOURCE_TAG="latest"
+ARG SOURCE_TAG="39"
 
 
 ### 2. SOURCE IMAGE


### PR DESCRIPTION
This PR downgrades the OS image from Fedora 40 to 39 in order to work around some weird problem with the Fedora 40 ISO installer's bootloader setup phase which causes an error in bootupd.