### PR TITLE
Bump the version of `forklift`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,23 +104,21 @@ GitHub/GitLab/etc. to prevent permanent loss of your changes.
 
 To modify your local copy of the pallet, you can use various subcommands of `forklift plt`, e.g.:
 
-- To disable the `dive-systemd-extension` package deployment (which makes the `dive` sysext
-  available to systemd), you can run `forklift plt disable-depl dive-systemd-extension`.
-  To re-enable the package deployment, you can run
-  `forklift plt enable-depl dive-systemd-extension`.
-- To disable the `systemd-service-enablement` feature flag (which enables `docker.service` as part
-  of systemd's service startup process) in the `docker-systemd-extension` package deployment,
-  you can run `forklift plt disable-depl-feat docker-systemd-extension systemd-service-enablement`.
-  To re-enable the feature flag, you can run
-  `forklift plt enable-depl-feat docker-systemd-extension systemd-service-enablement`.
+- To disable the `dive` package deployment (which makes the `dive` sysext available to systemd), you
+  can run `forklift plt disable-depl dive`. To re-enable the package deployment, you can run
+  `forklift plt enable-depl dive`.
+- To disable the `service` feature flag (which provides a confext to enable `docker.service` as part
+  of systemd's service startup process) in the `docker` package deployment, you can run
+  `forklift plt disable-depl-feat docker service`. To re-enable the feature flag, you can run
+  `forklift plt enable-depl-feat docker service`.
 
 Instead of running these subcommands and then running `forklift plt stage` to stage your modified
 pallet, you can enable an optional `--stage` flag in these subcommands to immediately stage the
 pallet after modifying the pallet. For example, you can run
-`forklift plt disable-depl --stage dive-systemd-extension` and reboot, after which the `dive`
-sysext will no longer be available to systemd. So you can think of
-`forklift plt enable-depl --stage` and `forklift plt disable-depl --stage` as the rough (but more
-verbose) equivalents of `systemctl enable` and `systemctl disable`.
+`forklift plt disable-depl --stage dive` and reboot, after which the `dive` sysext will no longer be
+available to systemd. So you can think of `forklift plt enable-depl --stage` and
+`forklift plt disable-depl --stage` as the rough (but more verbose) equivalents of
+`systemctl enable` and `systemctl disable`.
 
 ### By editing YAML files
 
@@ -129,7 +127,7 @@ Alternatively, you can directly edit files in `~/.local/share/forklift/pallet` a
 changes).
 
 For example, to disable the `dive` sysext, add the line `disabled: true` to
-`~/.local/share/forklift/pallet/deployments/dive-systemd-extension.deploy.yml`, run
+`~/.local/share/forklift/pallet/deployments/dive.deploy.yml`, run
 `forklift plt stage`, and reboot (or run `sudo forklift-stage-apply-systemd); then `dive` will no
 longer be available on your system.
 
@@ -335,11 +333,3 @@ Design/scope:
   to implement that was to have Forklift import github.com/docker/compose/v2 as a library. Making
   Forklift smaller is not a priority for me in the foreseeable future, but it would be nice to do
   eventually - assuming it doesn't add too much complexity.
-- The names of package deployments (e.g. `dive-systemd-extension` and `docker-systemd-extension`)
-  and feature flags (e.g. `systemd-service-enablement`) in the
-  github.com/ethanjli/pallet-example-exports pallet used by this demo are intentionally verbose to
-  be clear as examples, and they are more verbose than what you'd want for an ergonomic CLI user
-  experience. For example, you'd probably want your package deployments to be named something like
-  `dive` and `docker` instead (so that commands can instead look like
-  `forklift plt enable-depl dive`), and your feature flags to be named something like `service`
-  instead (so that commands can instead look like `forklift plt enable-depl-feat docker service`)

--- a/README.md
+++ b/README.md
@@ -91,21 +91,47 @@ available subcommands.
 
 ## Modify a pallet and use it
 
-I will eventually implement a nicer CLI workflow for modifying pallets, but for now in order to
-modify your local copy of the pallet you should directly edit files in
-`~/.local/share/forklift/pallet`. Then you can run `forklift pallet stage` and reboot (or run
-`sudo forklift-stage-apply-systemd` to preview your changes).
-
-For example, to disable the `dive` sysext, add the line `disabled: true` to
-`~/.local/share/forklift/pallet/deployments/dive-systemd-extension.deploy.yml`, run
-`forklift pallet stage`, and reboot (or run `sudo forklift-stage-apply-systemd); then `dive` will no
-longer be available on your system.
-
-Warning: if you have changes in `~/.local/share/forklift/pallet` which you haven't pushed up to
+You can edit your local copy of the pallet, which is at `~/.local/share/forklift/pallet`, either
+using the Forklift CLI or by directly editing YAML files in your local copy of the pallet; after
+making changes, you can stage (and apply) the modified pallet.
+Warning: if you have changes in your local pallet which you haven't pushed up to
 GitHub/etc. and then you run `forklift pallet switch {pallet-path}@{version-query}`, your
 modifications to your pallet will all be deleted/overwritten and replaced with the pallet you're
 switching to! If you are thinking of doing that, you should first commit and push your changes to
-GitHub/GitLab/etc.
+GitHub/GitLab/etc. to prevent permanent loss of your changes.
+
+### With the Forklift CLI
+
+To modify your local copy of the pallet, you can use various subcommands of `forklift plt`, e.g.:
+
+- To disable the `dive-systemd-extension` package deployment (which makes the `dive` sysext
+  available to systemd), you can run `forklift plt disable-depl dive-systemd-extension`.
+  To re-enable the package deployment, you can run
+  `forklift plt enable-depl dive-systemd-extension`.
+- To disable the `systemd-service-enablement` feature flag (which enables `docker.service` as part
+  of systemd's service startup process) in the `docker-systemd-extension` package deployment,
+  you can run `forklift plt disable-depl-feat docker-systemd-extension systemd-service-enablement`.
+  To re-enable the feature flag, you can run
+  `forklift plt enable-depl-feat docker-systemd-extension systemd-service-enablement`.
+
+Instead of running these subcommands and then running `forklift plt stage` to stage your modified
+pallet, you can enable an optional `--stage` flag in these subcommands to immediately stage the
+pallet after modifying the pallet. For example, you can run
+`forklift plt disable-depl --stage dive-systemd-extension` and reboot, after which the `dive`
+sysext will no longer be available to systemd. So you can think of
+`forklift plt enable-depl --stage` and `forklift plt disable-depl --stage` as the rough (but more
+verbose) equivalents of `systemctl enable` and `systemctl disable`.
+
+### By editing YAML files
+
+Alternatively, you can directly edit files in `~/.local/share/forklift/pallet` and then run
+`forklift plt stage` and reboot (or run `sudo forklift-stage-apply-systemd` to preview your
+changes).
+
+For example, to disable the `dive` sysext, add the line `disabled: true` to
+`~/.local/share/forklift/pallet/deployments/dive-systemd-extension.deploy.yml`, run
+`forklift plt stage`, and reboot (or run `sudo forklift-stage-apply-systemd); then `dive` will no
+longer be available on your system.
 
 # Explanation
 
@@ -231,19 +257,20 @@ systemd-sysext as part of a system extension directory assembled and exported by
 Hacks/workarounds:
 
 - This demo disables SELinux policy enforcement because of
-  <https://github.com/systemd/systemd/issues/23971>, and because I don't have enough experience with
-  SELinux to change the SELinux policy so that the overlays don't cause everything (e.g. sudo and
-  chkpwd) to break after systemd-sysext enables filesystem overlays (or maybe it's the bind mounts
-  I make in this demo for Forklift?), and because this is just a demo. If someone can fix
-  the SELinux policies for this demo, please submit a pull request at
+  <https://github.com/systemd/systemd/issues/23971> /
+  <https://github.com/systemd/systemd/issues/31404#issuecomment-1973478641>, and because I don't
+  have enough experience with SELinux to change the SELinux policy so that the overlays don't cause
+  everything (e.g. sudo and chkpwd) to break after systemd-sysext enables filesystem overlays (or
+  maybe it's the bind mounts I make in this demo for Forklift?), and because this is just a demo. If
+  someone can fix the SELinux policies for this demo, please submit a pull request at
   <https://github.com/ethanjli/ublue-forklift-sysext-demo/pulls>!
 - Because Flatcar's Docker system extension images are built to only be used on hosts whose
   `/usr/lib/os-release` files include `ID=flatcar` and `SYSEXT_LEVEL=1.0`, the bootable OS container
   images built by this repository lie that their OS ID is `flatcar` instead of `fedora` (even though
-  they are still just Fedora Linux), though the installer ISOs still use the standard (correct)
-  values `/usr/lib/os-release`, so after installing we still need to rebase onto the bootable OS
-  container provided by this repo. Yes, rewriting the os-release file's distro ID is a massive hack;
-  in my defense, I don't want to maintain my own fork of Flatcar's sysext-bakery just for a demo.
+  they are still just Fedora Linux). Yes, rewriting the os-release file's distro ID is a massive
+  hack; in my defense, I don't want to maintain my own fork of Flatcar's sysext-bakery just for a
+  demo. If/when the Universal Blue project starts releasing their own sysext images
+  at <https://github.com/ublue-os/sysext>, I will use those instead of Flatcar's sysext images.
 - Docker requires a mutable `/etc` in order to correctly set up firewall rules with
   firewalld/iptables, but systemd 256 (which is supposed to make it possible to have a mutable
   `/etc` even when confexts are active) has not been released yet. As a temporary workaround, this
@@ -251,22 +278,26 @@ Hacks/workarounds:
   `systemd-confext status` unable to detect the active confexts (even though they are indeed
   loaded and active).
 
-Scope:
+Design/scope:
 
-- To keep Forklift simple, I do not want to add functionality into Forklift to deduplicate large
-  files across staged pallet bundles in Forklift's stage store. However, I would be interested in
-  supporting use of OCI images rather than Git repos to distribute Forklift repos & pallets as well
-  as external/online files to be assembled into the export directory, in which case deduplication of
-  large sysext images could be feasible.
+- To keep Forklift simple, I would prefer not to add functionality into Forklift for deduplicating
+  large files across staged pallet bundles in Forklift's stage store. I am open to changing my mind,
+  especially if other people can give me advice or help out with the initial design or
+  implementation of such functionality.
 - To keep Forklift reasonably simple for my primary use-case for it and to keep it flexible enough
-  for maintainers of custom OS images to use according to their needs, I currently do not plan to
-  have Forklift manage FS mounts itself. So the workflow to change/update the sysexts/confexts on
-  the system will (probably) always involve modifying the local pallet (and then running
-  `forklift pallet stage`) or totally replacing the local pallet from a remote source, and then
-  either:
+  for maintainers of custom OS images to use in different ways according to their needs, I currently
+  do not plan to have Forklift manage FS mounts itself. So the workflow to change/update the
+  sysexts/confexts on the system will probably always involve either:
+
+      1. totally replacing the local pallet from a remote source, or
+      2. modifying the local pallet (and then staging the modified
+      pallet, either explicitly by running `forklift plt stage` afterwards or implicitly by
+      including the `--stage` flag on certain pallet-modifying subcommands of `forklift plt`),
+
+  and then either:
 
     1. rebooting (if you're on a custom OS image which integrates Forklift with
-       `/var/lib/extensions` and `/var/lib/confexts`, such as this repo's OS image); or
+       `/var/lib/extensions` and `/var/lib/confexts`, such as this repo's OS image), or
     2. running some command/script which re-mounts `/var/lib/extensions` and `/var/lib/confexts` and
        then reloads systemd's view of the sysexts/confexts (which is what this repo's
        `/usr/bin/forklift-stage-apply-systemd` script does).
@@ -274,13 +305,17 @@ Scope:
   If this workflow turns out to be too unwieldy, I'm potentially interested in the following
   possibilities:
 
-    1. making a separate tool which uses the same internal code as Forklift but provides a CLI
+    1. providing a way to use one or more shell scripts (which can include some steps to e.g. reload
+       systemd's view of sysexts/confexts) or shell commands as a hook to be automatically run by
+       Forklift after any operation which stages the local pallet; or
+    2. adjusting the design of what is currently implemented in Forklift so that it's a bit nicer
+       for managing sysexts/confexts, but without sacrificing usability in the other workflows which
+       Forklift must support; or
+    3. making a separate tool which uses the same internal code as Forklift but provides a CLI
        designed specifically for managing sysexts/confexts (and perhaps provides tighter integration
        for systemd and for management of FS mounts, and/or tighter integration with
        systemd-sysext/confext's extension paths); or
-    2. adjusting the design of what is currently implemented in Forklift so that it's a bit nicer
-       for managing sysexts/confexts, but without sacrificing usability in the other workflows which
-       Forklift must support;
+    4. something else
 
   but these are not high priorities for me in the near future because I am not daily-driving
   sysexts/confexts yet (and because the system I'm developing Forklift for has not finished its
@@ -293,15 +328,18 @@ Scope:
   to do so (but please follow the requirements of the Apache-2.0 license which Forklift is released
   under)! Warning: my code is still immature enough that it will probably undergo some additional
   major refactoring iterations, so don't expect too much in terms of quality. Also, I haven't
-  written any software tests yet 🫠.
-- The CLI for modifying pallets (e.g. adding package deployments) is still only partially
-  implemented; for anything besides adding/updating repo requirements (currently
-  `forklift dev pallet add-repo`, though I plan to add `forklift pallet require-repo` as a nicer
-  alias), I just use a file browser to manually create the necessary files. This means Forklift
-  currently doesn't have a CLI command for adding package deployments which would be roughly
-  analogous to `systemctl enable {unit}` or `apk add {package}`.
+  written thorough software tests yet - I just have a few end-to-end tests on certain parts of
+  Forklift 🫠.
 - Forklift is a large binary (~20 MB compressed, ~60 MB uncompressed) because it's also designed as
-  a tool to manage all Docker Compose apps deployed on a system, and the fastest/easiest way to
-  implement that was by including github.com/docker/compose/v2 as a library which I use. Making
+  a tool to manage all Docker Compose apps deployed on a system, and the fastest/easiest way for me
+  to implement that was to have Forklift import github.com/docker/compose/v2 as a library. Making
   Forklift smaller is not a priority for me in the foreseeable future, but it would be nice to do
   eventually - assuming it doesn't add too much complexity.
+- The names of package deployments (e.g. `dive-systemd-extension` and `docker-systemd-extension`)
+  and feature flags (e.g. `systemd-service-enablement`) in the
+  github.com/ethanjli/pallet-example-exports pallet used by this demo are intentionally verbose to
+  be clear as examples, and they are more verbose than what you'd want for an ergonomic CLI user
+  experience. For example, you'd probably want your package deployments to be named something like
+  `dive` and `docker` instead (so that commands can instead look like
+  `forklift plt enable-depl dive`), and your feature flags to be named something like `service`
+  instead (so that commands can instead look like `forklift plt enable-depl-feat docker service`)

--- a/build_files/forklift-extensions/build.sh
+++ b/build_files/forklift-extensions/build.sh
@@ -11,7 +11,7 @@ rpm-ostree install screen
 
 ### Install Forklift:
 
-FORKLIFT_VERSION="0.7.2-alpha.1"
+FORKLIFT_VERSION="0.7.2-alpha.2"
 # Do we need any other substitutions? We use goreleaser's defaults (e.g. `arm64` for 64-bit ARM, and
 # `arm` for armv7); it probably doesn't matter because for now ublue only has amd64 builds:
 FORKLIFT_ARCH="$(echo "$ARCH" | sed -e 's/x86_64/amd64/')"


### PR DESCRIPTION
This PR bumps `forklift` from v0.7.2-alpha.1 to v0.7.2-alpha.2 (and updates `README.md` accordingly) to provide a proper CLI for modifying package deployment declarations in the local pallet.