### PR TITLE
Try to fix the check for whether `/var/run/docker.sock` exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Next, you should reboot (or if you're *really* impatient and don't want to reboo
   `ls /usr/share/nvim/runtime/doc`; instead, you can find them by running
   `ls /usr/local/neovim/usr/share/nvim/runtime/doc`. And if you run
   `readelf -a /usr/local/neovim/usr/bin/nvim | grep -i musl`, you can see that `nvim` was compiled
-  for use with musl rather than glibc.
+  for dynamic library loading with musl rather than glibc.
 - If you open the Ptyxis terminal settings (assuming you're using the Bluefin-based OS image
   provided by this repo) and open the window to set a custom font, you will see the "JetBrains Mono"
   fonts appear in the font selection window.
@@ -290,16 +290,16 @@ part of a system extension directory assembled and exported by Forklift.
 Unlike `docker`, `dive`, and `crane`, [`nvim`](https://github.com/neovim/neovim) is not available as
 a statically-linked binary, so it depends on system libraries. For example, trying to run the
 binaries from [Neovim's GitHub Releases](https://github.com/neovim/neovim/releases) on Alpine Linux
-will not work due to the lack of glibc; instead, Alpine Linux's package for Neovim needs to be
-installed to use Neovim on Alpine Linux. The opposite is also true: trying to run a Neovim binary
-from Alpine Linux on a host without musl will also not work.
+will not work due to the lack of glibc on the system; instead, Alpine Linux's package for Neovim
+needs to be installed to use Neovim on Alpine Linux. The opposite is also true: trying to run a
+Neovim binary from Alpine Linux on a host without musl libraries will also not work.
 
 This repository includes a GitHub Actions workflow to automatically build a multi-arch container
 image which includes a `.raw` system extension image file with `nvim`, using
 [flatwrap](https://github.com/flatcar/sysext-bakery/blob/main/flatwrap.sh) with
 [Alpine Linux's neovim package](https://pkgs.alpinelinux.org/package/edge/community/x86/neovim)
-(which is linked against musl) to sandbox `nvim` in such a way that it work without any problems as
-a sysext on glibc-based systems.
+(which is dynamically linked against musl) to sandbox `nvim` in such a way that it work without any
+problems as a sysext on glibc-based systems.
 [Alpine Linux's neovim-doc package](https://pkgs.alpinelinux.org/package/edge/community/x86/neovim-doc)
 is also included in the sandbox with `nvim` so that `nvim` can access the associated documentation
 files without having those documentation files in the usual location where they would be if

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ do not exist yet, by looking for it in the list of system fonts when trying to s
 font in the Ptyxis terminal (Ptyxis is available if you're using the Bluefin-based OS image provided
 by this repo).
 
-Next, you should reboot (or if you're *really* impatient and don't want to reboot, run
-`sudo forklift-stage-apply-systemd`). Then you will see new system extensions if you run
+Next, you should reboot. Then you will see new system extensions if you run
 `systemd-sysext status`. You will also see that:
 
 - A new service named `hello-world-extension` ran successfully, if you check its status with
@@ -139,6 +138,9 @@ pallet after modifying the pallet. For example, you can run
 available to systemd. So you can think of `forklift plt enable-depl --stage` and
 `forklift plt disable-depl --stage` as the rough (but more verbose) equivalents of
 `systemctl enable` and `systemctl disable`.
+
+After staging the pallet, if you want to preview your changes without rebooting you can run
+`sudo forklift-stage-apply-systemd`.
 
 ### By editing YAML files
 

--- a/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
+++ b/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
@@ -84,7 +84,6 @@ systemctl restart --no-block sockets.target timers.target multi-user.target defa
 
 systemctl start sockets.target # block until sockets.target is done before checking for /var/run/docker.sock
 if [ -S /var/run/docker.sock ]; then
-  systemctl start docker.service || true
   echo "Updating Docker Compose apps..."
   forklift --stage-store="$FORKLIFT_STAGE_STORE" stage apply
 else

--- a/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
+++ b/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
@@ -84,6 +84,9 @@ systemctl restart --no-block sockets.target timers.target multi-user.target defa
 
 systemctl start sockets.target # block until sockets.target is done before checking for /var/run/docker.sock
 if [ -S /var/run/docker.sock ]; then
+  if systemctl status docker.service > /dev/null; then
+    systemctl start docker.service
+  fi
   echo "Updating Docker Compose apps..."
   forklift --stage-store="$FORKLIFT_STAGE_STORE" stage apply
 else

--- a/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
+++ b/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
@@ -82,6 +82,7 @@ systemctl restart --no-block sockets.target timers.target multi-user.target defa
 # consequences of doing so; but I'm personally not sure I fully understand those consequences, so
 # I'll just stick with what Flatcar Container Linux uses/used, tyvm)
 
+systemctl start sockets.target # block until sockets.target is done before checking for /var/run/docker.sock
 if [ -S /var/run/docker.sock ]; then
   echo "Updating Docker Compose apps..."
   forklift --stage-store="$FORKLIFT_STAGE_STORE" stage apply

--- a/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
+++ b/system_files/forklift-extensions/usr/bin/forklift-stage-apply-systemd
@@ -84,6 +84,7 @@ systemctl restart --no-block sockets.target timers.target multi-user.target defa
 
 systemctl start sockets.target # block until sockets.target is done before checking for /var/run/docker.sock
 if [ -S /var/run/docker.sock ]; then
+  systemctl start docker.service || true
   echo "Updating Docker Compose apps..."
   forklift --stage-store="$FORKLIFT_STAGE_STORE" stage apply
 else


### PR DESCRIPTION
Currently `forklift-stage-apply-systemd` finds that `/var/run/docker.sock` is missing even if the Docker sysext is loaded and `/var/run/docker.sock` exists after running `forklift-stage-apply-systemd`. This PR tries to make `forklift-stage-apply-systemd`'s check for the existence of `/var/run/docker.sock` more robust/correct.

Associated PRs: https://github.com/ethanjli/pallet-example-exports/pull/5