### PR TITLE
Adjust setup of bind mount permissions

### DIFF
--- a/system_files/forklift-extensions/usr/bin/just-setup-forklift-staging
+++ b/system_files/forklift-extensions/usr/bin/just-setup-forklift-staging
@@ -1,8 +1,11 @@
 #!/bin/bash -eux
 
 mkdir -p $HOME/.local/share/forklift/stages
-sudo mkdir -p /var/lib/forklift
-sudo mv $HOME/.local/share/forklift/stages /var/lib/forklift/stages
+sudo mkdir -p /var/lib/forklift/stages
+# TODO: maybe we should instead make a new "forklift" group which owns everything in
+# /var/lib/forklift?
+sudo chown $USER /var/lib/forklift/stages
+mkdir -p $HOME/.local/share/forklift/stages
 sudo systemctl enable --now bind-.local-share-forklift-stages@home-$USER.service
 
 ### Disable SELinux

--- a/system_files/forklift-extensions/usr/lib/systemd/system/bind-.local-share-forklift-stages@.service
+++ b/system_files/forklift-extensions/usr/lib/systemd/system/bind-.local-share-forklift-stages@.service
@@ -20,11 +20,7 @@ ExecStartPre=mkdir -p $TARGET
 # ownership rather than the default of root ownership; this should probably be considered a kludge
 # to allow Forklift's own CLI design to stay simple, and we may be able to simplify things by
 # improving Forklift's design (idk):
-ExecStart=bash -c '\
-  export MOUNT_UID=$(stat -c "%%u" %I) && \
-  export MOUNT_GID=$(stat -c "%%g" %I) && \
-  mount -o bind,uid=$MOUNT_UID,gid=$MOUNT_GID $SOURCE $TARGET \
-'
+ExecStart=bash -c 'mount -o bind $SOURCE $TARGET'
 # Note: `umount -l` is not recommended in general (see https://unix.stackexchange.com/a/390057)
 # because it just removes the mounts from the namespace while writes to open files can continue:
 ExecStopPost=umount -l $TARGET


### PR DESCRIPTION
This PR implements a discovery made in https://github.com/ethanjli/rpi-forklift-demo/pull/1 that the way I attempt to set user/group ownership for the bind mount of `/var/lib/forklift/stages` to `$HOME/.local/share/forklift/stages` doesn't actually work:

- https://superuser.com/questions/1362465/how-to-make-directory-accessible-to-others-using-bind-option
- https://superuser.com/questions/623375/mounting-directories-with-bind-different-permissions (this suggests using `mount -o bind,user` but that didn't work for me in testing either)

So in this PR I am trying to simplify how I set up ownership of `$HOME/.local/share/forklift/stages` when it's bind-mounted from `/var/lib/forklift/stages`.