### PR TITLE
Try building a sysext for busybox from alpine as an OCI image

### DIFF
--- a/.github/workflows/build-sysexts-scheduled.yml
+++ b/.github/workflows/build-sysexts-scheduled.yml
@@ -13,6 +13,7 @@ jobs:
           - bluefin-cli-alpine-flatwrap
           - bluefin-cli-wolfi-flatwrap
           - bluefin-cli-wolfi-flix
+          - busybox-alpine-flix
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-sysexts.yml
+++ b/.github/workflows/build-sysexts.yml
@@ -33,6 +33,7 @@ jobs:
           - bluefin-cli-alpine-flatwrap
           - bluefin-cli-wolfi-flatwrap
           - bluefin-cli-wolfi-flix
+          - busybox-alpine-flix
           - neovim
           - ublue-dx-fonts
     permissions:

--- a/Containerfile-base
+++ b/Containerfile-base
@@ -53,6 +53,7 @@ COPY system_files/forklift-extensions /
 
 RUN mkdir -p /var/lib/alternatives && \
     bash -c ". /tmp/build/build.sh" && \
+    rpm-ostree install elfutils && \
     rm -rf /tmp/* /var/* && \
     mkdir -p /var/tmp && \
     chmod -R 1777 /var/tmp && \

--- a/Containerfile-bluefin
+++ b/Containerfile-bluefin
@@ -53,6 +53,7 @@ COPY system_files/forklift-extensions /
 
 RUN mkdir -p /var/lib/alternatives && \
     bash -c ". /tmp/build/build.sh" && \
+    rpm-ostree install elfutils && \
     rm -rf /tmp/* /var/* && \
     mkdir -p /var/tmp && \
     chmod -R 1777 /var/tmp && \

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ After staging the pallet, if you want to preview your changes without rebooting 
 `sudo forklift-stage-apply-systemd`. This should be safe to do for the following sysexts:
 
 - `bluefin-cli`, provided by any of the following package deployments: `bluefin-cli-wolfi-flix`,
-  `bluefin-cli-wolfi-flatwrap`, or `bluefin-cli-alpine-flatwrap`.
+  `bluefin-cli-wolfi-flatwrap`, or `bluefin-cli-alpine-flatwrap`
+- `busybox`, provided by the `busybox-alpine-flix` package deployment
 - `crane`
 - `dive`
 - `neovim`

--- a/sysext-bakery/Containerfile.busybox-alpine-flix
+++ b/sysext-bakery/Containerfile.busybox-alpine-flix
@@ -2,7 +2,8 @@ FROM alpine:latest as original
 
 FROM alpine:latest as sandboxed
 RUN apk -U add \
-  bubblewrap \
+  patchelf \
+  grep \
   bash \
   coreutils \
   squashfs-tools btrfs-progs e2fsprogs e2fsprogs-extra

--- a/sysext-bakery/Containerfile.busybox-alpine-flix
+++ b/sysext-bakery/Containerfile.busybox-alpine-flix
@@ -1,0 +1,24 @@
+FROM alpine:latest as original
+
+FROM alpine:latest as sandboxed
+RUN apk -U add \
+  bubblewrap \
+  bash \
+  coreutils \
+  squashfs-tools btrfs-progs e2fsprogs e2fsprogs-extra
+COPY --from=original /bin /tmp/original/bin
+COPY --from=original /etc /tmp/original/etc
+COPY --from=original /lib /tmp/original/lib
+# /lib64 is needed by flix.sh:
+COPY --from=original /lib64 /tmp/original/lib64
+COPY --from=original /sbin /tmp/original/sbin
+COPY --from=original /usr /tmp/original/usr
+COPY flix.sh bake.sh .
+RUN \
+  OS="_any" ARCH="" RELOAD="0" KEEP="1" \
+  ./flix.sh /tmp/original busybox \
+    /bin/busybox:/usr/bin/busybox
+
+FROM scratch
+COPY --from=sandboxed busybox/usr /usr
+COPY extension-release-any /usr/lib/extension-release.d/extension-release.busybox

--- a/sysext-bakery/Containerfile.busybox-alpine-flix
+++ b/sysext-bakery/Containerfile.busybox-alpine-flix
@@ -9,8 +9,6 @@ RUN apk -U add \
 COPY --from=original /bin /tmp/original/bin
 COPY --from=original /etc /tmp/original/etc
 COPY --from=original /lib /tmp/original/lib
-# /lib64 is needed by flix.sh:
-COPY --from=original /lib64 /tmp/original/lib64
 COPY --from=original /sbin /tmp/original/sbin
 COPY --from=original /usr /tmp/original/usr
 COPY flix.sh bake.sh .

--- a/sysext-bakery/flatwrap.sh
+++ b/sysext-bakery/flatwrap.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env -S bash -x
 set -euo pipefail
 
 export ARCH="${ARCH-amd64}"

--- a/sysext-bakery/flix.sh
+++ b/sysext-bakery/flix.sh
@@ -75,10 +75,6 @@ find_deps() {
     NEW_RPATHS+=":/usr/local/${SYSEXTNAME}/${RP}"
   done
   patchelf --no-default-lib --set-rpath "${NEW_RPATHS}" "${FILE}"
-  # FIXME: delete the following three lines added for an experiment:
-  patchelf --no-default-lib --set-rpath "${NEW_RPATHS}" "${FILE}"
-  patchelf --no-default-lib --set-rpath "${NEW_RPATHS}" "${FILE}"
-  patchelf --no-default-lib --set-rpath "${NEW_RPATHS}" "${FILE}"
 }
 
 rm -rf "${SYSEXTNAME}"

--- a/sysext-bakery/flix.sh
+++ b/sysext-bakery/flix.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env -S bash -x
 set -euo pipefail
 
 export ARCH="${ARCH-amd64}"

--- a/sysext-bakery/flix.sh
+++ b/sysext-bakery/flix.sh
@@ -75,6 +75,10 @@ find_deps() {
     NEW_RPATHS+=":/usr/local/${SYSEXTNAME}/${RP}"
   done
   patchelf --no-default-lib --set-rpath "${NEW_RPATHS}" "${FILE}"
+  # FIXME: delete the following three lines added for an experiment:
+  patchelf --no-default-lib --set-rpath "${NEW_RPATHS}" "${FILE}"
+  patchelf --no-default-lib --set-rpath "${NEW_RPATHS}" "${FILE}"
+  patchelf --no-default-lib --set-rpath "${NEW_RPATHS}" "${FILE}"
 }
 
 rm -rf "${SYSEXTNAME}"


### PR DESCRIPTION
This PR is an experiment to help with troubleshooting https://github.com/89luca89/oci-sysext/pull/2, which has been unable to patch busybox from the [`alpine` image](https://hub.docker.com/_/alpine) using patchelf. This PR attempts to use sysext-bakery's flix.sh script (which just uses patchelf) to patch busybox, as a comparison to the approach taken in https://github.com/89luca89/oci-sysext/pull/2 .