### PR TITLE
Try using flix (i.e. patchelf) with a very long prefix path for busybox dependencies

### DIFF
--- a/.github/workflows/build-sysexts-scheduled.yml
+++ b/.github/workflows/build-sysexts-scheduled.yml
@@ -14,6 +14,7 @@ jobs:
           - bluefin-cli-wolfi-flatwrap
           - bluefin-cli-wolfi-flix
           - busybox-alpine-flix
+          - busybox-alpine-flix-longname
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-sysexts.yml
+++ b/.github/workflows/build-sysexts.yml
@@ -34,6 +34,7 @@ jobs:
           - bluefin-cli-wolfi-flatwrap
           - bluefin-cli-wolfi-flix
           - busybox-alpine-flix
+          - busybox-alpine-flix-longname
           - neovim
           - ublue-dx-fonts
     permissions:

--- a/sysext-bakery/Containerfile.busybox-alpine-flix-longname
+++ b/sysext-bakery/Containerfile.busybox-alpine-flix-longname
@@ -19,5 +19,5 @@ RUN \
     /bin/busybox:/usr/bin/busybox
 
 FROM scratch
-COPY --from=sandboxed busybox/usr /usr
+COPY --from=sandboxed busyboxbutwithareallylongsysextnametotrytobreakpatchelfhandlingofpathsjustasanexperiment/usr /usr
 COPY extension-release-any /usr/lib/extension-release.d/extension-release.busybox

--- a/sysext-bakery/Containerfile.busybox-alpine-flix-longname
+++ b/sysext-bakery/Containerfile.busybox-alpine-flix-longname
@@ -1,0 +1,23 @@
+FROM alpine:latest as original
+
+FROM alpine:latest as sandboxed
+RUN apk -U add \
+  patchelf \
+  grep \
+  bash \
+  coreutils \
+  squashfs-tools btrfs-progs e2fsprogs e2fsprogs-extra
+COPY --from=original /bin /tmp/original/bin
+COPY --from=original /etc /tmp/original/etc
+COPY --from=original /lib /tmp/original/lib
+COPY --from=original /sbin /tmp/original/sbin
+COPY --from=original /usr /tmp/original/usr
+COPY flix.sh bake.sh .
+RUN \
+  OS="_any" ARCH="" RELOAD="0" KEEP="1" \
+  ./flix.sh /tmp/original busyboxbutwithareallylongsysextnametotrytobreakpatchelfhandlingofpathsjustasanexperiment \
+    /bin/busybox:/usr/bin/busybox
+
+FROM scratch
+COPY --from=sandboxed busybox/usr /usr
+COPY extension-release-any /usr/lib/extension-release.d/extension-release.busybox


### PR DESCRIPTION
This PR follows up on the experiment in #10 (which successfully used flix.sh to sandbox alpine's busybox for use from a sysext) by trying to use a much longer prefix path with patchelf (by providing a very long sysext name to flix.sh).